### PR TITLE
fix handling of fixed (real) values in bank rebuild

### DIFF
--- a/s2repdump/main.py
+++ b/s2repdump/main.py
@@ -399,7 +399,7 @@ def rebuild_bank(gbank: GameBank, target_dir):
         key_curr = ET.Element('Key')
         key_curr.set('name', name)
         sc_curr.append(key_curr)
-        if kind:
+        if kind != None:
             enter_value(key_curr, kind, value)
         return key_curr
 


### PR DESCRIPTION
Talv,
    The bank rebuild functionality currently misshandles fixed (real) values and skips over them when generating the bank files. The issue is a conflation of the None type and the number 0, which is also false when treated as a boolean, causing fixed values to get skipped.